### PR TITLE
fix for delete bug in plant create form

### DIFF
--- a/house_plant_bst/plant/forms.py
+++ b/house_plant_bst/plant/forms.py
@@ -17,7 +17,7 @@ PlantCommonNameFormSet = inlineformset_factory(
     form=PlantCommonNameForm,
     fields=['name'],
     extra=1,
-    can_delete=False,
+    can_delete=True,
 )
 
 

--- a/house_plant_bst/static/js/jquery.formset.js
+++ b/house_plant_bst/static/js/jquery.formset.js
@@ -1,5 +1,5 @@
 /**
- * jQuery Formset 1.5-pre
+ * jQuery Formset 1.3-pre
  * @author Stanislaus Madueke (stan DOT madueke AT gmail DOT com)
  * @requires jQuery 1.2.6 or later
  *
@@ -9,7 +9,12 @@
  * Licensed under the New BSD License
  * See: http://www.opensource.org/licenses/bsd-license.php
  */
-;(function($) {
+
+  /**
+ repo => https://github.com/elo80ka/django-dynamic-formset
+ */
+
+ ;(function($) {
     $.fn.formset = function(opts)
     {
         var options = $.extend({}, $.fn.formset.defaults, opts),
@@ -55,26 +60,19 @@
             insertDeleteLink = function(row) {
                 var delCssSelector = $.trim(options.deleteCssClass).replace(/\s+/g, '.'),
                     addCssSelector = $.trim(options.addCssClass).replace(/\s+/g, '.');
-
-                var delButtonHTML = '<a class="' + options.deleteCssClass + '" href="javascript:void(0)">' + options.deleteText +'</a>';
-                if (options.deleteContainerClass) {
-                    // If we have a specific container for the remove button,
-                    // place it as the last child of that container:
-                    row.find('[class*="' + options.deleteContainerClass + '"]').append(delButtonHTML);
-                } else if (row.is('TR')) {
+                if (row.is('TR')) {
                     // If the forms are laid out in table rows, insert
                     // the remove button into the last table cell:
-                    row.children(':last').append(delButtonHTML);
+                    row.children(':last').append('<a class="' + options.deleteCssClass +'" href="javascript:void(0)">' + options.deleteText + '</a>');
                 } else if (row.is('UL') || row.is('OL')) {
                     // If they're laid out as an ordered/unordered list,
                     // insert an <li> after the last list item:
-                    row.append('<li>' + delButtonHTML + '</li>');
+                    row.append('<li><a class="' + options.deleteCssClass + '" href="javascript:void(0)">' + options.deleteText +'</a></li>');
                 } else {
                     // Otherwise, just insert the remove button as the
                     // last child element of the form's container:
-                    row.append(delButtonHTML);
+                    row.append('<a class="' + options.deleteCssClass + '" href="javascript:void(0)">' + options.deleteText +'</a>');
                 }
-
                 // Check if we're under the minimum number of forms - not to display delete link at rendering
                 if (!showDeleteLinks()){
                     row.find('a.' + delCssSelector).hide();
@@ -92,7 +90,6 @@
                         del.val('on');
                         row.hide();
                         forms = $('.' + options.formCssClass).not(':hidden');
-                        totalForms.val(forms.length);
                     } else {
                         row.remove();
                         // Update the TOTAL_FORMS count:
@@ -164,7 +161,6 @@
             } else {
                 // Otherwise, use the last form in the formset; this works much better if you've got
                 // extra (>= 1) forms (thnaks to justhamade for pointing this out):
-                if (options.hideLastAddForm) $('.' + options.formCssClass + ':last').hide();
                 template = $('.' + options.formCssClass + ':last').clone(true).removeAttr('id');
                 template.find('input:hidden[id $= "-DELETE"]').remove();
                 // Clear all cloned fields, except those the user wants to keep (thanks to brunogola for the suggestion):
@@ -182,32 +178,25 @@
             // FIXME: Perhaps using $.data would be a better idea?
             options.formTemplate = template;
 
-            var addButtonHTML = '<a class="' + options.addCssClass + '" href="javascript:void(0)">' + options.addText + '</a>';
-            if (options.addContainerClass) {
-                // If we have a specific container for the "add" button,
-                // place it as the last child of that container:
-                var addContainer = $('[class*="' + options.addContainerClass + '"');
-                addContainer.append(addButtonHTML);
-                addButton = addContainer.find('[class="' + options.addCssClass + '"]');
-            } else if ($$.is('TR')) {
+            if ($$.is('TR')) {
                 // If forms are laid out as table rows, insert the
                 // "add" button in a new table row:
                 var numCols = $$.eq(0).children().length,   // This is a bit of an assumption :|
-                    buttonRow = $('<tr><td colspan="' + numCols + '">' + addButtonHTML + '</tr>').addClass(options.formCssClass + '-add');
+                    buttonRow = $('<tr><td colspan="' + numCols + '"><a class="' + options.addCssClass + '" href="javascript:void(0)">' + options.addText + '</a></tr>')
+                                .addClass(options.formCssClass + '-add');
                 $$.parent().append(buttonRow);
+                if (hideAddButton) buttonRow.hide();
                 addButton = buttonRow.find('a');
             } else {
                 // Otherwise, insert it immediately after the last form:
-                $$.filter(':last').after(addButtonHTML);
+                $$.filter(':last').after('<a class="' + options.addCssClass + '" href="javascript:void(0)">' + options.addText + '</a>');
                 addButton = $$.filter(':last').next();
+                if (hideAddButton) addButton.hide();
             }
-
-            if (hideAddButton) addButton.hide();
-
             addButton.click(function() {
                 var formCount = parseInt(totalForms.val()),
                     row = options.formTemplate.clone(true).removeClass('formset-custom-template'),
-                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this),
+                    buttonRow = $($(this).parents('tr.' + options.formCssClass + '-add').get(0) || this)
                     delCssSelector = $.trim(options.deleteCssClass).replace(/\s+/g, '.');
                 applyExtraClasses(row, formCount);
                 row.insertBefore(buttonRow).show();
@@ -236,15 +225,12 @@
         formTemplate: null,              // The jQuery selection cloned to generate new form instances
         addText: 'add another',          // Text for the add link
         deleteText: 'remove',            // Text for the delete link
-        addContainerClass: null,         // Container CSS class for the add link
-        deleteContainerClass: null,      // Container CSS class for the delete link
         addCssClass: 'add-row',          // CSS class applied to the add link
         deleteCssClass: 'delete-row',    // CSS class applied to the delete link
         formCssClass: 'dynamic-form',    // CSS class applied to each form in a formset
         extraClasses: [],                // Additional CSS classes, which will be applied to each form in turn
         keepFieldValues: '',             // jQuery selector for fields whose values should be kept when the form is cloned
         added: null,                     // Function called each time a new form is added
-        removed: null,                   // Function called each time a form is deleted
-        hideLastAddForm: false           // When set to true, hide last empty add form (becomes visible when clicking on add button)
+        removed: null                    // Function called each time a form is deleted
     };
 })(jQuery);

--- a/house_plant_bst/templates/plant/plant_create.html
+++ b/house_plant_bst/templates/plant/plant_create.html
@@ -7,7 +7,7 @@
     <form action="" method="post">
         {% csrf_token %}
         {{ form|crispy }}
-        <!--{{ common_names_form|crispy }} -->
+
 
         <table class="table table-borderless">
             {{ common_names_form.management_form|crispy }}
@@ -18,7 +18,6 @@
                         <td>
                             {# Include the hidden fields in the form #}
                             {% if forloop.first %}
-                            Name*
                                 {% for hidden in form.hidden_fields %}
                                     {{ hidden }}
                                 {% endfor %}


### PR DESCRIPTION
- seems I was not using the same version of the jquery formset plugin as the example tutorial
- copied the jquery.formset.js straight from the [MyBook example repo](https://github.com/adandan01/mybook/blob/master/static/formset/jquery.formset.js) and it seems to be different from the file in `django-dynamic-formset` current repo
- for this you should not need to rerun a pip install for the requirements.txt, but for an extra sanity check I did go ahead and clear my browser cache before starting the server to make extra sure the new JS is loaded properly
- now deleting/adding new common names in the plant create form should work as expected