### PR TITLE
Fix reversion commits; re-add styles

### DIFF
--- a/static/styles/order_history.css
+++ b/static/styles/order_history.css
@@ -1,0 +1,20 @@
+.greenBackground {
+    background-color: rgba(141, 214, 207, 1);
+  }
+  .greyBackground {
+    background-color: rgba(236, 236, 236, 1);
+  }
+  .accordion-button:not(.collapsed) {
+    color: black;
+    font-weight: 400;
+    background-color: rgba(210, 230, 3, 1);
+    box-shadow: inset 0 -1px 0 rgb(0 0 0 / 13%);
+  }
+  
+    .disabledText {
+        opacity: 0.4;
+    }
+    .disabledLink {
+        pointer-events: none;
+        opacity: 0.4;
+    }

--- a/static/styles/plant_marketplace.css
+++ b/static/styles/plant_marketplace.css
@@ -42,3 +42,21 @@ button.btn.btn-secondary.dropdown-toggle {
     color: gray;
     border-color: lightgray;
 }
+
+a.scientific-name {
+    text-decoration: none;
+    color: black;
+}
+
+a.scientific-name:hover {
+    color: #b1d60d;
+}
+
+/* plant resources styles */
+a.custom-page-link {
+    color: black;
+}
+
+a.custom-page-link:hover {
+    color: #00b3a1;
+}

--- a/static/styles/trades.css
+++ b/static/styles/trades.css
@@ -19,3 +19,7 @@ div.card.create-trade-card {
 .btn.custom-back-btn {
     background-color: #e6f2f0;
 }
+
+div.col.trade-status-col {
+    border-right: solid 0.5px gray;
+}

--- a/templates/order/order_detail.html
+++ b/templates/order/order_detail.html
@@ -42,11 +42,11 @@
             {% for item in object.get_order_items.all %}
                 <tr>
                     <td><a href="{% url 'plant:marketplace_plant_detail' item.user_plant.pk %}">
-                        {{ item.user_plant.plant.scientific_name }}
+                        {{ item.user_plant.plant.scientific_name|capfirst }}
                     </a></td>
                     <td>{{ item.quantity }}</td>
                     <td>{{ item.user_plant.unit_price }}</td>
-                    <td>{{ item.user_plant.user.username }}</td>
+                    <td>{{ item.user_plant.user.username|capfirst }}</td>
                     <td>{{ object.get_handling_display }}</td>
                 </tr>
             {% endfor %}

--- a/templates/order/order_snippet.html
+++ b/templates/order/order_snippet.html
@@ -2,23 +2,23 @@
 
 <a href="{{ url }}" class="card-link ms-0 me-3 mb-3">
     <div class="card card-link ms-0 h-100" style="width: 18rem;">
-        <div class="card-header">
+        <div class="card-header" style="background: #dff2e7;">
             <div class="d-flex justify-content-between">
-                <h6 class="card-title">Order ID {{ object.id }}</h6>
+                <h6 class="card-title">Order #: {{ object.id }}</h6>
                 <small>${{ object.total_price }}</small>
             </div>
         </div>
         <div class="card-body">
             <div class="d-flex mb-1 justify-content-between">
                 {% for item in object.get_order_items.all %}
-                {{ item.user_plant.plant.scientific_name }}
-                    <p class='card-text text-muted' ># items: {{ item.quantity }}</p>
+                {{ item.user_plant.plant.scientific_name|capfirst }}
+                    <p class='card-text text-muted' ># Items: {{ item.quantity }}</p>
                 {% endfor %}
             </div>
             {% if object.buyer == user %}
-                <p class="mb-1">Seller: {{ object.seller }}</p>
+                <p class="mb-1">Seller: {{ object.seller|capfirst }}</p>
             {% else %}
-                <p class="mb-1">Buyer: {{ object.buyer }}</p>
+                <p class="mb-1">Buyer: {{ object.buyer|capfirst }}</p>
             {% endif %}
             <p class="card-text">Handling method: {{ object.get_handling_display }}</p>
         </div>

--- a/templates/order/user_order_list.html
+++ b/templates/order/user_order_list.html
@@ -2,30 +2,8 @@
 {% load static %}
 
 {% block head %}
-<style>
-  .greenBackground {
-    background-color: rgba(210, 230, 3, 0.6);
-  }
-  .greyBackground {
-    background-color: rgba(236, 236, 236, 1);
-  }
-  .accordion-button:not(.collapsed) {
-    color: black;
-    font-weight: 400;
-    background-color: rgba(210, 230, 3, 1);
-    box-shadow: inset 0 -1px 0 rgb(0 0 0 / 13%);
-  }
-  h2, h5, h6 {
-    font-family: var(--bs-body-font-family);
-  }
-    .disabledText {
-        opacity: 0.4;
-    }
-    .disabledLink {
-        pointer-events: none;
-        opacity: 0.4;
-    }
-</style>
+<link rel="stylesheet" type="text/css" href="{% static 'styles/order_history.css' %}" />
+
 {% endblock %}
 
 {% block content %}
@@ -37,6 +15,7 @@
 </div>
 
 <h3 class="mt-0">My Plant Purchases</h3>
+<div class="col bg-white m-1 custom-card p-2">
 <div class="accordion" id="accordionPanelsStayOpenExample">
     <!-- User's purchases -->
     <!-- New/Open purchases -->
@@ -114,9 +93,11 @@
         </div>
       </div>
     </div>
+  </div>
 </div>
 
 <h3 class="mt-4">My Sold Plants</h3>
+<div class="col bg-white mx-1 mt-1 mb-3 custom-card p-2">
 <div class="accordion" id="accordionSoldPlants">
     <!-- User's sold plants -->
     <!-- New/Open sold items -->
@@ -194,6 +175,10 @@
         </div>
       </div>
     </div>
+  </div>
 </div>
 
+
+<!-- Decorative green block div in background -->
+<div class="decorative-bg-div"></div>
 {% endblock %}

--- a/templates/plant/plant_detail.html
+++ b/templates/plant/plant_detail.html
@@ -11,7 +11,7 @@
 <div class="container my-3">
     <div class="card">
       <div class="card-body pb-0">
-        <h3 class="card-title">{{ object.scientific_name }}</h3>
+        <h3 class="card-title">{{ object.scientific_name|capfirst }}</h3>
         <h4 class="card-subtitle text-muted">Common names:
             <span>
                 {% for name in object.get_common_names.all %}

--- a/templates/plant/plant_list.html
+++ b/templates/plant/plant_list.html
@@ -35,7 +35,7 @@
                 <a href="{% url 'plant:plant_detail' object.pk %}" class="card-link">
                     <div class="card-body">
                         <h4 class="card-title">
-                            {{ object.scientific_name }}      
+                            {{ object.scientific_name|capfirst }}      
                         </h4>
                         <p class="card-text text-muted">
                             Common names:
@@ -56,23 +56,26 @@
 </div>
 
 
-<div class="pagination my-3">
-    <span class="step-links">
+<nav class="plant-resources-pagination ps-2">
+    <ul class="pagination">
+
         {% if page_obj.has_previous %}
-            <a href="?page=1">&laquo; first</a>
-            <a href="?page={{ page_obj.previous_page_number }}">previous</a>
+        <li class="page-item"><a href="?page=1" class="page-link custom-page-link">&laquo; First</a></li>
+        <li class="page-item"><a href="?page={{ page_obj.previous_page_number }}" class="page-link custom-page-link">Previous</a></li>
         {% endif %}
 
-        <span class="current">
-            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
-        </span>
+        <li class="page-item disabled"><a href="" class="page-link">
+            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+            </a>
+        </li>
 
         {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}">next</a>
-            <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
+            <li class="page-item"><a href="?page={{ page_obj.next_page_number }}" class="page-link custom-page-link">Next</a></li>
+            <li class="page-item"><a href="?page={{ page_obj.paginator.num_pages }}" class="page-link custom-page-link">Last &raquo;</a></li>
         {% endif %}
-    </span>
-</div>
+    </ul>
+</nav>
+
 
 {{ common_names }}
 

--- a/templates/plant/userplant/userplant_detail.html
+++ b/templates/plant/userplant/userplant_detail.html
@@ -13,8 +13,8 @@
   <div class="card" style="width: 23rem;">
     <img class="img-fluid" src="{% if object.image_url != '' %} {{ object.image_url}} {% else %} {% static 'images/default_userplant_image.png' %} {% endif %}" >
     <div class="card-body">
-      <h3 class="card-title">{{ object.plant.scientific_name }}</h3>
-      <h5 class="card-title">${{ object.unit_price }}</h5>
+      <h3 class="card-title">{{ object.plant.scientific_name|capfirst }}</h3>
+      <h5 class="card-title plant-price">${{ object.unit_price }}</h5>
       <h6 class="card-title">Quantity Available: {{ object.quantity }}</h6>
       <!-- Pill-Tags -->
       <div class="tags my-2">

--- a/templates/plant/userplant/userplant_list.html
+++ b/templates/plant/userplant/userplant_list.html
@@ -63,15 +63,16 @@
     <div class="col-sm-6 py-3">
       <div class="card border-light h-100">
           <img class="card-img-top marketplace-plant-img" src="{% if object.userplant.image_url != '' %} {{ object.userplant.image_url}} {% else %} {% static 'images/default_userplant_image.png' %} {% endif %}" alt="Card image cap">
-          <div class="card-body">
-              <h5 class="card-subtitle my-1" style="display: inline-block; white-space: nowrap;">
+          <div class="card-body ps-2 pe-1 py-1">
+              <h5 class="card-subtitle my-1" style="display: inline-block;">
                 <!-- Scientific name links to marketplace or userplant detail page -->
                 <a 
                 href="{% if marketplace %} 
                         {% url 'plant:marketplace_plant_detail' object.userplant.pk %}
                       {% else %}
                         {% url 'plant:userplant_detail' object.userplant.pk %}
-                      {% endif %}">
+                      {% endif %}"
+                class="scientific-name">
                     {{ object.userplant.plant.scientific_name|capfirst }}
                 </a>
               </h5>
@@ -94,7 +95,7 @@
 
 
               <!-- Seller and location info -->
-              <p class="plant-card-text">
+              <p class="plant-card-text mb-1">
                   Seller: {{ object.userplant.user.username|capfirst }}
                   <br>
                   Location: {{ object.location }}

--- a/templates/trade/order_history.html
+++ b/templates/trade/order_history.html
@@ -1,125 +1,142 @@
 {% extends 'base.html' %}
+{% load static %}
 {% load crispy_forms_tags %}
-{% block content %}
 
+{% block head %}
+<link rel="stylesheet" type="text/css" href="{% static 'styles/order_history.css' %}" />
+
+{% endblock %}
+
+{% block content %}
 
 <div class="container my-3">
     {% if user.is_authenticated %}
     <!-- Show Order History if user is logged in -->
-        <h3>{{ user.get_username|capfirst }}'s <span class="h-text">Order</span> History</h3>
+        <h3><span class="h-text">Trade</span> Order History</h3>
         <br>
-        <!-- TODO: Buy/Sell Orders Section -->
+    <!-- Pending Trades -->
+    <h4>Pending Trades</h4>
+    <div class="col bg-white mx-1 mb-3 custom-card p-2">
+        {% if trades_pending %}
+            {% for trade in trades_pending %}
+            <div class="card shadow-sm my-3">
+                <h6 class="card-header trade-card-header">
+                    <div class="row">
+                        <div class="col">
+                            Trade #: {{trade.pk}}
+                        </div>
+                        <div class="col">
+                            Status: Awaiting Response
+                        </div>
+                    </div>
+                </h6>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col">
+                            <h6>Seller:
+                                {% if trade.seller.get_username == None %}
+                                Deleted User
+                                {% else %}
+                                {{ trade.seller.get_username|capfirst }}
+                                {% endif %} 
+                            </h6>
+                        </div>
+                        <div class="col">
+                            <h6> Buyer: 
+                                {% if trade.buyer.get_username == None %}
+                                Deleted User
+                                {% else %}
+                                {{ trade.buyer.get_username|capfirst }}
+                                {% endif %} 
+                            </h6>
+                        </div>
+                    </div>
+                    <a class="stretched-link" href="{% url 'trade:trade' trade.pk %}"></a>
+                </div>
+                <div class="card-footer text-muted">
+                    Requested: {{ trade.request_date }}
+                </div>
+            </div>
+           {% endfor %}
         
+        {% else %}
+        <h5 class="text-center text-muted">There are no pending trades</h5>
+        {% endif %}
+    </div>
 
-        <!-- Trades Section -->
-        <h3> Trades </h3>
-        <div class="row">
-            <!-- Row headers -->
-            <div class="col">
-                <h4>Pending Trades</h4>
-            </div>
-            <div class="col">
-                <h4>Closed Trades</h4>
-            </div>
-        </div>
 
-        <div class="row">
-            <!-- Pending Trades -->
-            <div class="col bg-white m-1 custom-card py-2">
-                {% if trades_pending %}
-                    {% for trade in trades_pending %}
-                    <div class="card shadow-sm my-3">
-                        <h6 class="card-header trade-card-header">
-                            <div class="row">
-                                <div class="col">
-                                    Trade #: {{trade.pk}}
-                                </div>
-                                <div class="col">
-                                    Status: Awaiting Response
-                                </div>
-                            </div>
-                        </h6>
-                        <div class="card-body">
-                            <div class="row">
-                                <div class="col">
-                                    <h6>Seller:
-                                        {% if trade.seller.get_username == None %}
-                                        Deleted User
-                                        {% else %}
-                                        {{ trade.seller.get_username|capfirst }}
-                                        {% endif %} 
-                                    </h6>
-                                </div>
-                                <div class="col">
-                                    <h6> Buyer: 
-                                        {% if trade.buyer.get_username == None %}
-                                        Deleted User
-                                        {% else %}
-                                        {{ trade.buyer.get_username|capfirst }}
-                                        {% endif %} 
-                                    </h6>
-                                </div>
-                            </div>
-                            <a class="stretched-link" href="{% url 'trade:trade' trade.pk %}"></a>
-                        </div>
-                    </div>
-                   {% endfor %}
-                
-                {% else %}
-                <h5 class="text-center text-muted">There are no pending trades</h5>
-                {% endif %}
+    <!-- Closed Trades -->
+    <h4>Closed Trades</h4>
+    <div class="col bg-white mx-1 mb-3 custom-card p-2">
+        {% if trades_closed %}
+            
+        <!-- Accepted Trades -->
+        <div class="accordion" id="accordionPanelsStayOpenExample">
+            <div class="accordion-item mb-2">
+              <h2 class="accordion-header" id="panelsStayOpen-headingOne">
+                <button class="accordion-button collapsed fs-5 {% if trades_accepted|length > 0 %}greenBackground {% else %}greyBackground{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseOne" aria-expanded="true" aria-controls="panelsStayOpen-collapseOne">
+                  Accepted <span class='ms-4'>{{ trades_accepted|length }} Result{{ trades_accepted|pluralize }}</span>
+                </button>
+              </h2>
+              <div id="panelsStayOpen-collapseOne" class="accordion-collapse collapse" aria-labelledby="panelsStayOpen-headingOne">
+                <div class="accordion-body">
+                {% for trade in trades_accepted %}
+                    {% url 'trade:trade' trade.pk as trade_detail_url %}
+                    {% include 'trade/trade_snippet.html' with url=trade_detail_url trade=trade%}
+                {% endfor %}
+                </div>
+              </div>
             </div>
 
-            <!-- Closed Trades -->
-            <div class="col bg-white m-1 custom-card py-2">
-                {% if trades_closed %}
-                    {% for trade in trades_closed %}
-                    <div class="card shadow-sm my-3">
-                        <h6 class="card-header trade-card-header">
-                            <div class="row">
-                                <div class="col">
-                                    Trade #: {{trade.pk}}
-                                </div>
-                                <div class="col">
-                                    Status: {{trade.get_trade_status_display}}
-                                </div>
-                            </div>
-                        </h6>
-                        <div class="card-body">
-                            <div class="row">
-                                <div class="col">
-                                    <h6>Seller: 
-                                        {% if trade.seller.get_username == None %}
-                                        Deleted User
-                                        {% else %}
-                                        {{ trade.seller.get_username|capfirst }}
-                                        {% endif %}
-                                    </h6>
-                                </div>
-                                <div class="col">
-                                    <h6> Buyer: 
-                                        {% if trade.buyer.get_username == None %}
-                                        Deleted User
-                                        {% else %}
-                                        {{ trade.buyer.get_username|capfirst }}
-                                        {% endif %}
-                                    </h6>
-                                </div>
-                            </div>
-                            <a class="stretched-link" href="{% url 'trade:trade' trade.pk %}"></a>
-                        </div>
-                    </div>
-                   {% endfor %}
-                {% else %}
-                   <h5 class="text-center text-muted">There are no closed trades</h5>
-                {% endif %}
+            <!-- Rejected Trades -->
+            <div class="accordion-item mb-2">
+              <h2 class="accordion-header" id="panelsStayOpen-headingTwo">
+                <button class="accordion-button collapsed fs-5 {% if trades_rejected|length > 0 %}greenBackground {% else %}greyBackground{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseTwo" aria-expanded="false" aria-controls="panelsStayOpen-collapseTwo">
+                    Rejected <span class='ms-4'>{{ trades_rejected|length }} Result{{ trades_rejected|pluralize }}</span>
+                </button>
+              </h2>
+              <div id="panelsStayOpen-collapseTwo" class="accordion-collapse collapse" aria-labelledby="panelsStayOpen-headingTwo">
+                <div class="accordion-body">
+                    {% for trade in trades_rejected %}
+                    {% url 'trade:trade' trade.pk as trade_detail_url %}
+                    {% include 'trade/trade_snippet.html' with url=trade_detail_url trade=trade%}
+                {% endfor %}
+                </div>
+              </div>
+            </div>
+
+
+            <!-- Unavailable Trades -->
+            <div class="accordion-item mb-2">
+              <h2 class="accordion-header" id="panelsStayOpen-headingThree">
+                <button class="accordion-button collapsed fs-5 {% if trades_unavailable|length > 0 %}greenBackground {% else %}greyBackground{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseThree" aria-expanded="false" aria-controls="panelsStayOpen-collapseThree">
+                    Unavailable <span class='ms-4'>{{ trades_unavailable|length }} Result{{ trades_unavailable|pluralize }}</span>
+                </button>
+              </h2>
+              <div id="panelsStayOpen-collapseThree" class="accordion-collapse collapse" aria-labelledby="panelsStayOpen-headingThree">
+                <div class="accordion-body">
+                    {% for trade in trades_unavailable %}
+                    {% url 'trade:trade' trade.pk as trade_detail_url %}
+                    {% include 'trade/trade_snippet.html' with url=trade_detail_url trade=trade%}
+                {% endfor %}
+                </div>
+              </div>
             </div>
         </div>
 
+        {% else %}
+           <h5 class="text-center text-muted">There are no closed trades</h5>
+        {% endif %}
+    </div>
+
+    
     {% else %}
         <h3>Login to see your trades</h3>
     {% endif %}
 </div>
+
+
+
 
 
 <!-- Decorative green block div in background -->

--- a/templates/trade/trade.html
+++ b/templates/trade/trade.html
@@ -4,6 +4,21 @@
 {% block content %}
 
 {% if user.is_authenticated %}
+
+<!-- if the trade has been accepted, show a message letting the requester and seller know to coordinate receipt -->
+{% if trade.trade_status == 'AC' %}
+<div class="container m-3">
+    <div class="alert alert-success text-center">
+        {% if request.user == trade.buyer %}
+            <h4>Congratulations, {{ trade.seller.get_username|capfirst }} has accepted your trade request!</h4>
+        {% elif request.user == trade.seller %}
+            <h4>Congratulations on accepting {{ trade.buyer.get_username|capfirst }}'s trade request!</h4>
+        {% endif %}
+        <p class="mb-0">Coordinate the receipt of the plants by using the messaging feature below</p>
+    </div>
+</div>
+{% endif %}
+
 <div class="container d-flex justify-content-center m-3">
 
     <div class="card">
@@ -14,13 +29,36 @@
                     <h5>Trade #: {{ trade.pk }}</h5>
                 </div>
                 <div class="col d-flex justify-content-end">
+                    {% if trade.trade_status != 'AC' %}
                     <h5>Trade Status: {{ trade.get_trade_status_display }}</h5>
                     <!-- if the trade has been accepted, show accepted plant name and handling method -->
-                    {% if trade.trade_status == 'AC' %}
+                    {% elif trade.trade_status == 'AC' %}
                         {% for trade_item in trade_item_list %}
                             {% if trade_item.chosen_flag %}
-                            <h5>Accepted Plant: {{ trade_item.user_plant.plant.scientific_name|capfirst }}</h5>
-                            <h5>Handling: {{ trade.get_accepted_handling_method_display }}</h5>
+                            <div class="col text-center trade-status-col">
+                                <div class="row">
+                                    <h5>Trade Status:</h5>
+                                </div>
+                                <div class="row">
+                                    <p class="mb-0">{{ trade.get_trade_status_display }}</p>
+                                </div>
+                            </div>
+                            <div class="col text-center trade-status-col">
+                                <div class="row">
+                                    <h5>Accepted Plant:</h5>
+                                </div>
+                                <div class="row">
+                                    <p class="mb-0">{{ trade_item.user_plant.plant.scientific_name|capfirst }}</p>
+                                </div>
+                            </div>
+                            <div class="col text-center">
+                                <div class="row">
+                                    <h5>Handling:</h5>
+                                </div>
+                                <div class="row">
+                                    <p class="mb-0">{{ trade.get_accepted_handling_method_display }}</p>
+                                </div>
+                            </div>
                             {% endif %}
                         {% endfor %}
                     {% endif %}
@@ -32,22 +70,6 @@
             <!-- show message if no trade items exist -->
             {% if trade_item_list.all.count == 0 %}
             <p>No Trade Items</p>
-            {% endif %}
-
-            <!-- if the trade has been accepted, show a message letting the requester and seller know to coordinate receipt -->
-            {% if trade.trade_status == 'AC' %}
-                <div class="row">
-                    <div class="card border-white">
-                        <br>
-                        {% if request.user == trade.buyer %}
-                            <h4>Congratulations, {{ trade.seller.get_username|capfirst }} has accepted your trade request!</h4>
-                        {% elif request.user == trade.seller %}
-                            <h4>Congratulations on accepting {{ trade.buyer.get_username|capfirst }}'s trade request!</h4>
-                        {% endif %}
-                        <p>Coordinate the receipt of the plants by using the messaging feature below</p>
-                        <br>
-                    </div>
-                </div>
             {% endif %}
 
             <!-- Show the trade request -->
@@ -122,6 +144,7 @@
             </div>
             <!-- Display requester's address, if specified -->
             {% if trade.address and trade.accepted_handling_method != 'PI' %}
+                <hr>
                 <div class="row">
                     <div class="card border-white">
                         <h4>Shipping address:</h4>

--- a/templates/trade/trade_snippet.html
+++ b/templates/trade/trade_snippet.html
@@ -1,0 +1,43 @@
+<div class="card shadow-sm my-3">
+    <h6 class="card-header trade-card-header">
+        <div class="row">
+            <div class="col">
+                Trade #: {{trade.pk}}
+            </div>
+            <div class="col">
+                Status: {{trade.get_trade_status_display}}
+            </div>
+        </div>
+    </h6>
+    <div class="card-body">
+        <div class="row">
+            <div class="col">
+                <h6>Seller: 
+                    {% if trade.seller.get_username == None %}
+                    Deleted User
+                    {% else %}
+                    {{ trade.seller.get_username|capfirst }}
+                    {% endif %}
+                </h6>
+            </div>
+            <div class="col">
+                <h6> Buyer: 
+                    {% if trade.buyer.get_username == None %}
+                    Deleted User
+                    {% else %}
+                    {{ trade.buyer.get_username|capfirst }}
+                    {% endif %}
+                </h6>
+            </div>
+
+        </div>
+        <a class="stretched-link" href="{{ trade_detail_url }}"></a>
+    </div>
+    <div class="card-footer text-muted">
+        {% if trade.trade_status != 'UN' %}
+            Response Date: {{ trade.response_date }}
+        {% else %}
+            Plant is temporarily out of stock
+        {% endif %}
+    </div>
+</div> 

--- a/trade/views.py
+++ b/trade/views.py
@@ -94,9 +94,16 @@ class OrderHistory(View):
                 _update_unavailable_trades(trade, trade.seller)
             trades_pending = trades.filter(trade_status='SE')
             trades_closed = trades.exclude(trade_status='SE')
+            trades_accepted = trades.filter(trade_status='AC')
+            trades_rejected = trades.filter(trade_status='RE')
+            trades_unavailable = trades.filter(trade_status='UN')
             context = {
                 'trades_pending': trades_pending,
-                'trades_closed': trades_closed
+                'trades_closed': trades_closed,
+                'trades_closed': trades_closed,
+                'trades_accepted': trades_accepted,
+                'trades_rejected': trades_rejected,
+                'trades_unavailable': trades_unavailable
             }
             return render(request, 'trade/order_history.html', context)
         else:


### PR DESCRIPTION
- cleaned up Plant Marketplace styles
  - added text wrap to scientific names
  - removed blue hyperlink styles
  - cleaned up card padding
- styled pagination buttons on Plant Resources page
- add capitalization in various pages
- cleaned up Trade Detail page
  - formatted "Accepted - congrats" message as alert and moved to top of page
  - formatted trade status details (status, accepted plant, handling
  - added horizontal rule before shipping address
- cleaned up Purchase Order History page
  - changed header colors/ header font style
  - added container with green border for Bought/Sold sections
  - moved styles to separate CSS file for reuse in Trade Order History
- reformat Trade Order History page to match Purchase Order History page
  - Closed Trades section uses accordion cards for Accepted, Rejected, Unavailable categories
    - added Accepted, Rejected, Unavailable filters to trade/views.py /OrderHIstoryView and added to context
    - added Response/Request dates to trade snippet footers